### PR TITLE
Remove lifetimes from parser::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "haproxy-config"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 
 rust-version = "1.65" # let-else

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,10 +22,10 @@ use super::sections::*;
 /// // Build a config from the sections
 /// let config = Config::try_from(sections.as_slice()).unwrap();
 /// ```
-pub fn parse_sections(input: &str) -> Result<Vec<Section>, Error<'_>> {
+pub fn parse_sections(input: &str) -> Result<Vec<Section>, Error> {
     parser::configuration(input).map_err(|e| Error {
         inner: e,
-        source: input,
+        source: input.to_string(),
         path: None,
     })
 }
@@ -133,7 +133,7 @@ peg::parser! {
 
         pub(super) rule group_line() -> Line<'input>
             = _ "group" _ name:group_name() _ users:users()? comment:comment_text()? line_break() eof()? {
-                Line::Group { name, users: users.unwrap_or_else(Vec::new), comment }
+                Line::Group { name, users: users.unwrap_or_default(), comment }
             }
 
         rule password_type() -> bool

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -8,20 +8,20 @@ use peg::error::ParseError;
 use peg::str::LineCol;
 
 #[derive(Debug)]
-pub struct Error<'input> {
+pub struct Error {
     pub inner: ParseError<LineCol>,
-    pub source: &'input str,
+    pub source: String,
     pub path: Option<PathBuf>,
 }
 
-impl std::fmt::Display for Error<'_> {
+impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut bytes = Vec::new();
         {
             let buf = BufWriter::new(&mut bytes);
 
             self.report()
-                .write((self.path(), Source::from(self.source)), buf)
+                .write((self.path(), Source::from(&self.source)), buf)
                 .unwrap();
         }
 
@@ -30,13 +30,13 @@ impl std::fmt::Display for Error<'_> {
     }
 }
 
-impl std::error::Error for Error<'_> {
+impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }
 }
 
-impl<'i> Error<'i> {
+impl Error {
     pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
         self.path = Some(path.into());
         self


### PR DESCRIPTION
These make it hard to use the error upstream. For example using type erasure such as anyhow and color::eyre.